### PR TITLE
Shell Script installation files for macOS and linux

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+python -m ensurepip --upgrade
+pip install -r requirements-linux.txt

--- a/install-mac.sh
+++ b/install-mac.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+python -m ensurepip --upgrade
+pip install -r requirements-unix.txt


### PR DESCRIPTION
macOS version works fine, installs both pip and required files. 
Should probably check the linux version and then update the readme. 
I'll experiment with one for windows. 